### PR TITLE
Specify cert bundle path for superset oauth

### DIFF
--- a/superset/base/superset_config.py
+++ b/superset/base/superset_config.py
@@ -112,7 +112,8 @@ class CustomSecurityManager(SupersetSecurityManager):
 
     def oauth_user_info(self, provider, response=None):
         me = self.appbuilder.sm.oauth_remotes[provider].get(
-            "apis/user.openshift.io/v1/users/~"
+            "apis/user.openshift.io/v1/users/~",
+            verify=COMBINED_CERT_BUNDLE
         )
         data = me.json()
         username = data.get('metadata').get('name')


### PR DESCRIPTION
We've found that in specific configurations of openshift, it is necessary to overrided the value of the default python requests library's certificate bundle location. This change forces the oauth call here to use the cert bundle that we create up above, which should allow oauth to keep working when customized deployments have overriden the value of the "CURL_CA_BUNDLE" env var.